### PR TITLE
Add functions to set identifiers on AST node and edge patterns

### DIFF
--- a/lib/src/ast_node_pattern.c
+++ b/lib/src/ast_node_pattern.c
@@ -86,8 +86,17 @@ const cypher_astnode_t *cypher_ast_node_pattern_get_identifier(
 }
 
 
-unsigned int cypher_ast_node_pattern_nlabels(const cypher_astnode_t *astnode)
-{
+void cypher_ast_node_pattern_set_identifier(const cypher_astnode_t *astnode,
+        const cypher_astnode_t *identifier) {
+    REQUIRE_TYPE(astnode, CYPHER_AST_NODE_PATTERN, NULL);
+    REQUIRE_TYPE(identifier, CYPHER_AST_IDENTIFIER, NULL);
+    struct node_pattern *node = container_of(astnode, struct node_pattern, _astnode);
+    assert(node->identifier == NULL && identifier != NULL);
+    node->identifier = identifier;
+}
+
+
+unsigned int cypher_ast_node_pattern_nlabels(const cypher_astnode_t *astnode) {
     REQUIRE_TYPE(astnode, CYPHER_AST_NODE_PATTERN, 0);
     struct node_pattern *node =
             container_of(astnode, struct node_pattern, _astnode);

--- a/lib/src/ast_node_pattern.c
+++ b/lib/src/ast_node_pattern.c
@@ -86,17 +86,31 @@ const cypher_astnode_t *cypher_ast_node_pattern_get_identifier(
 }
 
 
-void cypher_ast_node_pattern_set_identifier(const cypher_astnode_t *astnode,
-        const cypher_astnode_t *identifier) {
+void cypher_ast_node_pattern_set_identifier(cypher_astnode_t *astnode,
+        cypher_astnode_t *identifier)
+{
     REQUIRE_TYPE(astnode, CYPHER_AST_NODE_PATTERN, NULL);
     REQUIRE_TYPE(identifier, CYPHER_AST_IDENTIFIER, NULL);
-    struct node_pattern *node = container_of(astnode, struct node_pattern, _astnode);
+    struct node_pattern *node =
+        container_of(astnode, struct node_pattern, _astnode);
     assert(node->identifier == NULL && identifier != NULL);
     node->identifier = identifier;
+    unsigned int n = astnode->nchildren;
+    if(n == 0)
+    {
+        astnode->children = malloc(sizeof(cypher_astnode_t *));
+    }
+    else
+    {
+        astnode->children =
+            realloc(astnode->children, (n + 1) * sizeof(cypher_astnode_t *));
+    }
+    astnode->children[astnode->nchildren++] = identifier;
 }
 
 
-unsigned int cypher_ast_node_pattern_nlabels(const cypher_astnode_t *astnode) {
+unsigned int cypher_ast_node_pattern_nlabels(const cypher_astnode_t *astnode)
+{
     REQUIRE_TYPE(astnode, CYPHER_AST_NODE_PATTERN, 0);
     struct node_pattern *node =
             container_of(astnode, struct node_pattern, _astnode);

--- a/lib/src/ast_rel_pattern.c
+++ b/lib/src/ast_rel_pattern.c
@@ -93,12 +93,22 @@ enum cypher_rel_direction cypher_ast_rel_pattern_get_direction(
 
 
 const cypher_astnode_t *cypher_ast_rel_pattern_get_identifier(
-        const cypher_astnode_t *astnode)
-{
-    REQUIRE_TYPE(astnode, CYPHER_AST_REL_PATTERN, NULL);
-    struct rel_pattern *node =
-            container_of(astnode, struct rel_pattern, _astnode);
-    return node->identifier;
+	const cypher_astnode_t *astnode) {
+	REQUIRE_TYPE(astnode, CYPHER_AST_REL_PATTERN, NULL);
+	struct rel_pattern *node =
+		container_of(astnode, struct rel_pattern, _astnode);
+	return node->identifier;
+}
+
+
+void cypher_ast_rel_pattern_set_identifier(
+	const cypher_astnode_t *astnode, const cypher_astnode_t *identifier) {
+	REQUIRE_TYPE(astnode, CYPHER_AST_REL_PATTERN, NULL);
+	REQUIRE_TYPE(identifier, CYPHER_AST_IDENTIFIER, NULL);
+	struct rel_pattern *node =
+		container_of(astnode, struct rel_pattern, _astnode);
+	assert(node->identifier == NULL && identifier != NULL);
+	node->identifier = identifier;
 }
 
 

--- a/lib/src/ast_rel_pattern.c
+++ b/lib/src/ast_rel_pattern.c
@@ -93,22 +93,35 @@ enum cypher_rel_direction cypher_ast_rel_pattern_get_direction(
 
 
 const cypher_astnode_t *cypher_ast_rel_pattern_get_identifier(
-	const cypher_astnode_t *astnode) {
-	REQUIRE_TYPE(astnode, CYPHER_AST_REL_PATTERN, NULL);
-	struct rel_pattern *node =
-		container_of(astnode, struct rel_pattern, _astnode);
-	return node->identifier;
+        const cypher_astnode_t *astnode)
+{
+    REQUIRE_TYPE(astnode, CYPHER_AST_REL_PATTERN, NULL);
+    struct rel_pattern *node =
+            container_of(astnode, struct rel_pattern, _astnode);
+    return node->identifier;
 }
 
 
-void cypher_ast_rel_pattern_set_identifier(
-	const cypher_astnode_t *astnode, const cypher_astnode_t *identifier) {
-	REQUIRE_TYPE(astnode, CYPHER_AST_REL_PATTERN, NULL);
-	REQUIRE_TYPE(identifier, CYPHER_AST_IDENTIFIER, NULL);
-	struct rel_pattern *node =
-		container_of(astnode, struct rel_pattern, _astnode);
-	assert(node->identifier == NULL && identifier != NULL);
-	node->identifier = identifier;
+void cypher_ast_rel_pattern_set_identifier(cypher_astnode_t *astnode,
+        cypher_astnode_t *identifier)
+{
+    REQUIRE_TYPE(astnode, CYPHER_AST_REL_PATTERN, NULL);
+    REQUIRE_TYPE(identifier, CYPHER_AST_IDENTIFIER, NULL);
+    struct rel_pattern *node =
+        container_of(astnode, struct rel_pattern, _astnode);
+    assert(node->identifier == NULL && identifier != NULL);
+    node->identifier = identifier;
+    unsigned int n = astnode->nchildren;
+    if(n == 0)
+    {
+        astnode->children = malloc(sizeof(cypher_astnode_t *));
+    }
+    else
+    {
+        astnode->children =
+            realloc(astnode->children, (n + 1) * sizeof(cypher_astnode_t *));
+    }
+    astnode->children[astnode->nchildren++] = identifier;
 }
 
 

--- a/lib/src/cypher-parser.h.in
+++ b/lib/src/cypher-parser.h.in
@@ -5049,6 +5049,18 @@ const cypher_astnode_t *cypher_ast_node_pattern_get_identifier(
         const cypher_astnode_t *node);
 
 /**
+ * Set the identifier of a `CYPHER_AST_NODE_PATTERN` node.
+ *
+ * If the node is not an instance of `CYPHER_AST_NODE_PATTERN` then the result
+ * will be undefined.
+ *
+ * @param [node] The AST node.
+ * @param [identifier] The identifer to set.
+ */
+void cypher_ast_node_pattern_set_identifier(const cypher_astnode_t *node,
+        const cypher_astnode_t *identifier);
+
+/**
  * Get the number of labels in a `CYPHER_AST_NODE_PATTERN` node.
  *
  * If the node is not an instance of `CYPHER_AST_NODE_PATTERN` then the result
@@ -5137,6 +5149,19 @@ enum cypher_rel_direction cypher_ast_rel_pattern_get_direction(
 __cypherlang_pure
 const cypher_astnode_t *cypher_ast_rel_pattern_get_identifier(
         const cypher_astnode_t *node);
+
+/**
+ * Set the identifier of a `CYPHER_AST_REL_PATTERN` node.
+ *
+ * If the node is not an instance of `CYPHER_AST_REL_PATTERN` then the result
+ * will be undefined.
+ *
+ * @param [node] The AST node.
+ * @param [identifier] The identifer node to set.
+
+ */
+void cypher_ast_rel_pattern_set_identifier(
+	const cypher_astnode_t *node, const cypher_astnode_t *identifier);
 
 /**
  * Get the number of reltypes in a `CYPHER_AST_REL_PATTERN` node.

--- a/lib/src/cypher-parser.h.in
+++ b/lib/src/cypher-parser.h.in
@@ -5057,8 +5057,8 @@ const cypher_astnode_t *cypher_ast_node_pattern_get_identifier(
  * @param [node] The AST node.
  * @param [identifier] The identifer to set.
  */
-void cypher_ast_node_pattern_set_identifier(const cypher_astnode_t *node,
-        const cypher_astnode_t *identifier);
+void cypher_ast_node_pattern_set_identifier(cypher_astnode_t *node,
+        cypher_astnode_t *identifier);
 
 /**
  * Get the number of labels in a `CYPHER_AST_NODE_PATTERN` node.
@@ -5158,10 +5158,9 @@ const cypher_astnode_t *cypher_ast_rel_pattern_get_identifier(
  *
  * @param [node] The AST node.
  * @param [identifier] The identifer node to set.
-
  */
-void cypher_ast_rel_pattern_set_identifier(
-	const cypher_astnode_t *node, const cypher_astnode_t *identifier);
+void cypher_ast_rel_pattern_set_identifier( cypher_astnode_t *node,
+        cypher_astnode_t *identifier);
 
 /**
  * Get the number of reltypes in a `CYPHER_AST_REL_PATTERN` node.


### PR DESCRIPTION
Hi @cleishm,

This PR extends the libcypher-parser API such that identifiers can be added to nodes and relations after the AST has been created. We have found this to be a useful feature for standardizing our AST accesses.

I'm not aware of another place in this repository that modifies `children` arrays as we do here, which is necessary to properly free the added identifiers. Please let me know if anything should be changed to better match the project's style!