### PR TITLE
Add AST annotation API

### DIFF
--- a/lib/src/Makefile.am
+++ b/lib/src/Makefile.am
@@ -2,6 +2,8 @@ lib_LTLIBRARIES = libcypher-parser.la
 
 include_HEADERS = cypher-parser.h
 libcypher_parser_la_SOURCES = \
+	annotation.c \
+	annotation.h \
 	ast.c \
 	ast.h \
 	astnode.h \

--- a/lib/src/annotation.c
+++ b/lib/src/annotation.c
@@ -1,0 +1,263 @@
+/* vi:set ts=4 sw=4 expandtab:
+ *
+ * Copyright 2016, Chris Leishman (http://github.com/cleishm)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "../../config.h"
+#include "annotation.h"
+#include "astnode.h"
+#include "util.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+static struct cypher_astnode_annotation *find_annotation(
+        const cypher_ast_annotation_context_t *context,
+        const cypher_astnode_t *node);
+static void attach_annotation_to_astnode(
+        const cypher_astnode_t *node,
+        struct cypher_astnode_annotation *annotation);
+static void detach_annotation_from_astnode(
+        struct cypher_astnode_annotation *annotation);
+static void attach_annotation_to_context(
+        cypher_ast_annotation_context_t *context,
+        struct cypher_astnode_annotation *annotation);
+static void detach_annotation_from_context(
+        struct cypher_astnode_annotation *annotation);
+
+
+cypher_ast_annotation_context_t *cypher_ast_annotation_context(void)
+{
+    cypher_ast_annotation_context_t *context =
+            malloc(sizeof(cypher_ast_annotation_context_t));
+    memset(context, 0, sizeof(cypher_ast_annotation_context_t));
+    return context;
+}
+
+
+void cypher_ast_annotation_context_set_release_handler(
+        cypher_ast_annotation_context_t *context,
+        cypher_ast_annotation_context_release_handler_t handler,
+        void *userdata)
+{
+    context->release_cb = handler;
+    context->release_cb_userdata = (handler == NULL) ? NULL : userdata;
+}
+
+
+void cypher_ast_annotation_context_free(
+        cypher_ast_annotation_context_t *context)
+{
+    if (context == NULL)
+    {
+        return;
+    }
+
+    while (context->annotations != NULL)
+    {
+        cp_release_annotation(context->annotations);
+    }
+    free(context);
+}
+
+
+int cypher_astnode_attach_annotation(cypher_ast_annotation_context_t *context,
+        const cypher_astnode_t *node, void *annotation,
+        void **previous_annotation)
+{
+    REQUIRE(context != NULL, -1);
+    REQUIRE(node != NULL, -1);
+    REQUIRE(annotation != NULL, -1);
+
+    struct cypher_astnode_annotation *annotation_node = find_annotation(
+            context, node);
+    if (annotation_node != NULL)
+    {
+        if (previous_annotation != NULL)
+        {
+            *previous_annotation = annotation_node->data;
+        }
+        annotation_node->data = annotation;
+        return 0;
+    }
+
+    annotation_node = malloc(sizeof(struct cypher_astnode_annotation));
+    if (annotation_node == NULL)
+    {
+        return -1;
+    }
+    memset(annotation_node, 0, sizeof(struct cypher_astnode_annotation));
+    annotation_node->data = annotation;
+
+    attach_annotation_to_astnode(node, annotation_node);
+    attach_annotation_to_context(context, annotation_node);
+
+    if (previous_annotation != NULL)
+    {
+        *previous_annotation = NULL;
+    }
+
+    return 0;
+}
+
+
+void *cypher_astnode_remove_annotation(cypher_ast_annotation_context_t *context,
+        const cypher_astnode_t *node)
+{
+    REQUIRE(context != NULL, NULL);
+    REQUIRE(node != NULL, NULL);
+
+    struct cypher_astnode_annotation *annotation = find_annotation(
+            context, node);
+    if (annotation == NULL)
+    {
+        return NULL;
+    }
+
+    assert(node == annotation->astnode);
+    assert(context == annotation->context);
+
+    detach_annotation_from_astnode(annotation);
+    detach_annotation_from_context(annotation);
+
+    void *data = annotation->data;
+    free(annotation);
+    return data;
+}
+
+
+void *cypher_astnode_get_annotation(
+        const cypher_ast_annotation_context_t *context,
+        const cypher_astnode_t *node)
+{
+    REQUIRE(context != NULL, NULL);
+    REQUIRE(node != NULL, NULL);
+
+    struct cypher_astnode_annotation *annotation = find_annotation(
+            context, node);
+    if (annotation == NULL)
+    {
+        return NULL;
+    }
+    return annotation->data;
+}
+
+
+struct cypher_astnode_annotation *find_annotation(
+        const cypher_ast_annotation_context_t *context,
+        const cypher_astnode_t *node)
+{
+    // search using the astnode as it will typically have less items
+    struct cypher_astnode_annotation *annotation = node->annotations;
+    while (annotation != NULL && annotation->context != context)
+    {
+        annotation = annotation->node_next;
+    }
+    return annotation;
+}
+
+
+void attach_annotation_to_astnode(const cypher_astnode_t *node,
+        struct cypher_astnode_annotation *annotation)
+{
+    annotation->astnode = node;
+
+    // insert at head of list on the astnode (overriding the const qualifier)
+    cypher_astnode_t *astnode = (cypher_astnode_t *)(uintptr_t)node;
+    annotation->node_next = astnode->annotations;
+    if (astnode->annotations != NULL)
+    {
+        astnode->annotations->node_prev = annotation;
+    }
+    astnode->annotations = annotation;
+}
+
+
+void detach_annotation_from_astnode(
+        struct cypher_astnode_annotation *annotation)
+{
+    if (annotation->node_next != NULL)
+    {
+        annotation->node_next->node_prev = annotation->node_prev;
+    }
+    if (annotation->node_prev == NULL)
+    {
+        cypher_astnode_t *astnode =
+            (cypher_astnode_t *)(uintptr_t)annotation->astnode;
+        astnode->annotations = annotation->node_next;
+    }
+    else
+    {
+        annotation->node_prev->node_next = annotation->node_next;
+    }
+    annotation->astnode = NULL;
+    annotation->node_next = NULL;
+    annotation->node_prev = NULL;
+}
+
+
+void attach_annotation_to_context(cypher_ast_annotation_context_t *context,
+        struct cypher_astnode_annotation *annotation)
+{
+    annotation->context = context;
+
+    // insert at head of list on the context
+    annotation->ctx_next = context->annotations;
+    if (context->annotations != NULL)
+    {
+        context->annotations->ctx_prev = annotation;
+    }
+    context->annotations = annotation;
+}
+
+
+void detach_annotation_from_context(
+        struct cypher_astnode_annotation *annotation)
+{
+    // remove from context list
+    if (annotation->ctx_next != NULL)
+    {
+        annotation->ctx_next->ctx_prev = annotation->ctx_prev;
+    }
+    if (annotation->ctx_prev == NULL)
+    {
+        annotation->context->annotations = annotation->ctx_next;
+    }
+    else
+    {
+        annotation->ctx_prev->ctx_next = annotation->ctx_next;
+    }
+    annotation->context = NULL;
+    annotation->ctx_next = NULL;
+    annotation->ctx_prev = NULL;
+}
+
+
+void cp_release_annotation(struct cypher_astnode_annotation *annotation)
+{
+    assert(annotation != NULL);
+
+    cypher_ast_annotation_context_t *context = annotation->context;
+
+    detach_annotation_from_astnode(annotation);
+    detach_annotation_from_context(annotation);
+    if (context->release_cb != NULL)
+    {
+        context->release_cb(context->release_cb_userdata,
+                annotation->astnode, annotation->data);
+    }
+
+    free(annotation);
+}

--- a/lib/src/annotation.h
+++ b/lib/src/annotation.h
@@ -1,0 +1,48 @@
+/* vi:set ts=4 sw=4 expandtab:
+ *
+ * Copyright 2016, Chris Leishman (http://github.com/cleishm)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CYPHER_PARSER_ANNOTATION_H
+#define CYPHER_PARSER_ANNOTATION_H
+
+#include "cypher-parser.h"
+
+
+struct cypher_astnode_annotation
+{
+    cypher_ast_annotation_context_t *context;
+    const cypher_astnode_t *astnode;
+    void *data;
+
+    struct cypher_astnode_annotation *node_prev;
+    struct cypher_astnode_annotation *node_next;
+
+    struct cypher_astnode_annotation *ctx_prev;
+    struct cypher_astnode_annotation *ctx_next;
+};
+
+
+struct cypher_ast_annotation_context
+{
+    cypher_ast_annotation_context_release_handler_t release_cb;
+    void *release_cb_userdata;
+    struct cypher_astnode_annotation *annotations;
+};
+
+
+void cp_release_annotation(struct cypher_astnode_annotation *annotation);
+
+
+#endif/*CYPHER_PARSER_ANNOTATION_H*/

--- a/lib/src/ast.c
+++ b/lib/src/ast.c
@@ -462,6 +462,12 @@ void cypher_ast_free(cypher_astnode_t *ast)
     {
         return;
     }
+
+    while (ast->annotations != NULL)
+    {
+        cp_release_annotation(ast->annotations);
+    }
+
     assert(ast->type < _MAX_VT_OFF);
     const struct cypher_astnode_vt *vt = VT_PTR(ast->type);
     vt->free(ast);

--- a/lib/src/astnode.h
+++ b/lib/src/astnode.h
@@ -18,6 +18,7 @@
 #define CYPHER_PARSER_ASTNODE_H
 
 #include "cypher-parser.h"
+#include "annotation.h"
 #include "ast.h"
 #include "util.h"
 
@@ -39,6 +40,7 @@ struct cypher_astnode
     unsigned int nchildren;
     struct cypher_input_range range;
     unsigned int ordinal;
+    struct cypher_astnode_annotation *annotations;
 };
 
 

--- a/lib/src/cypher-parser.h.in
+++ b/lib/src/cypher-parser.h.in
@@ -5403,6 +5403,93 @@ int cypher_ast_fprint(const cypher_astnode_t *ast, FILE *stream,
 
 /*
  * =====================================
+ * abstract syntax tree annotations
+ * =====================================
+ */
+
+/**
+ * A context for AST annotations.
+ */
+typedef struct cypher_ast_annotation_context cypher_ast_annotation_context_t;
+
+/**
+ * Create a new AST annotation context.
+ *
+ * @return An annotation context, or NULL if an error occurs
+ *         (errno will be set).
+ */
+cypher_ast_annotation_context_t *cypher_ast_annotation_context(void);
+
+/**
+ * An annotation release handler.
+ */
+typedef void (*cypher_ast_annotation_context_release_handler_t)(
+        void *userdata, const cypher_astnode_t *node, void *annotation);
+
+/**
+ * Set a handler to be invoked when an annotation is released.
+ *
+ * Attached annotations will be released when either the astnode or the
+ * annotation context is released.
+ *
+ * @param [context] The AST annotation context.
+ * @param [handler] The handler function, which may be NULL.
+ * @param [userdata] A pointer that will be provided to the handler.
+ */
+void cypher_ast_annotation_context_set_release_handler(
+        cypher_ast_annotation_context_t *context,
+        cypher_ast_annotation_context_release_handler_t handler,
+        void *userdata);
+
+/**
+ * Release an AST annotation context.
+ *
+ * If set, the annotation release handler will be invoked for all
+ * annotations set within this context.
+ *
+ * @param [context] The AST annotation context.
+ */
+void cypher_ast_annotation_context_free(
+        cypher_ast_annotation_context_t *context);
+
+/**
+ * Attach an annotation to an AST node.
+ *
+ * @param [context] The annotation context.
+ * @param [node] The AST node.
+ * @param [annotation] The annotation to attach.
+ * @param [previous_annotation] A pointer to a pointer, which will be
+ *        set to the address of the previous annotation, if any, or NULL.
+ * @return 0 on success, or -1 if an error occurs (errno will be set).
+ */
+int cypher_astnode_attach_annotation(cypher_ast_annotation_context_t *context,
+        const cypher_astnode_t *node, void *annotation,
+        void **previous_annotation);
+
+/**
+ * Remove an annotation from an AST node.
+ *
+ * @param [context] The annotation context.
+ * @param [node] The AST node.
+ * @return The removed annotation, or NULL.
+ */
+void *cypher_astnode_remove_annotation(cypher_ast_annotation_context_t *context,
+        const cypher_astnode_t *node);
+
+/**
+ * Get an annotation from an AST node.
+ *
+ * @param [context] The annotation context.
+ * @param [node] The AST node.
+ * @return The attached annotation, or NULL.
+ */
+void *cypher_astnode_get_annotation(
+        const cypher_ast_annotation_context_t *context,
+        const cypher_astnode_t *node);
+
+
+/*
+ * =====================================
  * parser
  * =====================================
  */
@@ -5785,7 +5872,7 @@ __cypherlang_pure
 unsigned int cypher_parse_result_nroots(const cypher_parse_result_t *result);
 
 /**
- * Get a root AST nodes from a parse result.
+ * Get a root AST node from a parse result.
  *
  * @param [result] The parse result.
  * @param [index] The node index.

--- a/lib/test/Makefile.am
+++ b/lib/test/Makefile.am
@@ -8,6 +8,7 @@ check_libcypher_parser_SOURCES = \
 	memstream.h
 
 check_libcypher_parser_CHECKS = \
+	check_annotation.c \
 	check_call.c \
 	check_case.c \
 	check_command.c \

--- a/lib/test/check_annotation.c
+++ b/lib/test/check_annotation.c
@@ -1,0 +1,151 @@
+/* vi:set ts=4 sw=4 expandtab:
+ *
+ * Copyright 2016, Chris Leishman (http://github.com/cleishm)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "../../config.h"
+#include "../../lib/src/cypher-parser.h"
+#include "memstream.h"
+#include <check.h>
+#include <errno.h>
+#include <unistd.h>
+
+
+static cypher_parse_result_t *result;
+static const cypher_astnode_t *ast;
+static const cypher_astnode_t *query;
+static const cypher_astnode_t *match;
+static unsigned released;
+
+
+static void setup(void)
+{
+    result = cypher_parse("MATCH (n:Label) RETURN n", NULL, NULL, 0);
+    ck_assert_ptr_ne(result, NULL);
+
+    ast = cypher_parse_result_get_directive(result, 0);
+    query = cypher_ast_statement_get_body(ast);
+    match = cypher_ast_query_get_clause(query, 0);
+
+    released = 0;
+}
+
+
+static void teardown(void)
+{
+    cypher_parse_result_free(result);
+}
+
+
+START_TEST (annotate_single_node)
+{
+    cypher_ast_annotation_context_t *ctx = cypher_ast_annotation_context();
+
+    ck_assert_ptr_eq(cypher_astnode_get_annotation(ctx, match), NULL);
+
+    void *ptr1 = (void *)"foo";
+    ck_assert_int_eq(cypher_astnode_attach_annotation(ctx, match, ptr1, NULL), 0);
+    ck_assert_ptr_eq(cypher_astnode_get_annotation(ctx, match), ptr1);
+
+    void *ptr2 = (void *)"bar";
+    void *ptr3 = ptr2;
+    ck_assert_int_eq(cypher_astnode_attach_annotation(ctx, match, ptr2, &ptr3), 0);
+    ck_assert_ptr_eq(ptr3, ptr1);
+    ck_assert_ptr_eq(cypher_astnode_get_annotation(ctx, match), ptr2);
+
+    cypher_astnode_remove_annotation(ctx, match);
+    ck_assert_ptr_eq(cypher_astnode_get_annotation(ctx, match), NULL);
+
+    cypher_ast_annotation_context_free(ctx);
+}
+END_TEST
+
+
+START_TEST (annotate_multiple_nodes)
+{
+    cypher_ast_annotation_context_t *ctx = cypher_ast_annotation_context();
+
+    ck_assert_ptr_eq(cypher_astnode_get_annotation(ctx, query), NULL);
+    ck_assert_ptr_eq(cypher_astnode_get_annotation(ctx, match), NULL);
+
+    void *ptr1 = (void *)"foo";
+    ck_assert_int_eq(cypher_astnode_attach_annotation(ctx, query, ptr1, NULL), 0);
+    ck_assert_ptr_eq(cypher_astnode_get_annotation(ctx, query), ptr1);
+    ck_assert_ptr_eq(cypher_astnode_get_annotation(ctx, match), NULL);
+
+    void *ptr2 = (void *)"bar";
+    void *ptr3 = ptr2;
+    ck_assert_int_eq(cypher_astnode_attach_annotation(ctx, match, ptr2, &ptr3), 0);
+    ck_assert_ptr_eq(ptr3, NULL);
+    ck_assert_ptr_eq(cypher_astnode_get_annotation(ctx, query), ptr1);
+    ck_assert_ptr_eq(cypher_astnode_get_annotation(ctx, match), ptr2);
+
+    cypher_ast_annotation_context_free(ctx);
+
+    ck_assert_ptr_eq(cypher_astnode_get_annotation(ctx, query), NULL);
+    ck_assert_ptr_eq(cypher_astnode_get_annotation(ctx, match), NULL);
+}
+END_TEST
+
+
+static void release_handler(void *userdata, const cypher_astnode_t *node,
+        void *annotation)
+{
+    released++;
+    ck_assert_ptr_eq(annotation, userdata);
+}
+
+
+START_TEST (annotations_are_released_on_context_free)
+{
+    cypher_ast_annotation_context_t *ctx = cypher_ast_annotation_context();
+
+    void *ptr1 = (void *)"foo";
+
+    cypher_ast_annotation_context_set_release_handler(ctx, release_handler, ptr1);
+    ck_assert_int_eq(cypher_astnode_attach_annotation(ctx, query, ptr1, NULL), 0);
+    cypher_ast_annotation_context_free(ctx);
+    ck_assert_int_eq(released, 1);
+}
+END_TEST
+
+
+START_TEST (annotations_are_released_on_ast_free)
+{
+    cypher_ast_annotation_context_t *ctx = cypher_ast_annotation_context();
+
+    void *ptr1 = (void *)"foo";
+
+    cypher_ast_annotation_context_set_release_handler(ctx, release_handler, ptr1);
+    ck_assert_int_eq(cypher_astnode_attach_annotation(ctx, query, ptr1, NULL), 0);
+    cypher_parse_result_free(result);
+    result = NULL;
+    ck_assert_int_eq(released, 1);
+
+    cypher_ast_annotation_context_free(ctx);
+    ck_assert_int_eq(released, 1);
+}
+END_TEST
+
+
+TCase* annotation_tcase(void)
+{
+    TCase *tc = tcase_create("annotation");
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_add_test(tc, annotate_single_node);
+    tcase_add_test(tc, annotate_multiple_nodes);
+    tcase_add_test(tc, annotations_are_released_on_context_free);
+    tcase_add_test(tc, annotations_are_released_on_ast_free);
+    return tc;
+}


### PR DESCRIPTION
The AST annotation API provides an easy way to attach annotations to nodes in an abstract syntax tree.

The `cypher_ast_annotation_context_t` provides a context for a set of annotations, and each context supporting attaching one annotation per astnode.

A callback handler is supported, allowing annotations to be released when the AST or the annotation context are free'd.