### PR TITLE
added params type support

### DIFF
--- a/lib/src/ast_cypher_option_param.c
+++ b/lib/src/ast_cypher_option_param.c
@@ -46,7 +46,6 @@ cypher_astnode_t *cypher_ast_cypher_option_param(const cypher_astnode_t *name,
         unsigned int nchildren, struct cypher_input_range range)
 {
     REQUIRE_CHILD(children, nchildren, name, CYPHER_AST_STRING, NULL);
-    REQUIRE_CHILD(children, nchildren, value, CYPHER_AST_STRING, NULL);
 
     struct cypher_option_param *node =
             calloc(1, sizeof(struct cypher_option_param));

--- a/lib/src/parser.leg
+++ b/lib/src/parser.leg
@@ -71,7 +71,17 @@ cypher-version = <
 cypher-param = < n:cypher-param-name - EQUAL - v:cypher-param-val >
                                        { $$ = cypher_option_param(n, v); }
 cypher-param-name = < [a-zA-Z0-9_]+ >  { $$ = block_string(); }
-cypher-param-val = < (!WS .)+ >        { $$ = block_string(); }
+cypher-param-val = p:cypher-param-value        { $$ = p; }
+
+cypher-param-value =  
+      true-literal
+    | false-literal
+    | null-literal
+    | string-literal
+    | float-literal
+    | integer-literal
+    | collection-literal
+    | map-literal
 
 profile-option = < PROFILE >           { $$ = profile_option(); }
 explain-option = < EXPLAIN >           { $$ = explain_option(); }

--- a/lib/test/check_statement.c
+++ b/lib/test/check_statement.c
@@ -148,24 +148,162 @@ START_TEST (parse_statement_with_cypher_option_containing_version)
 END_TEST
 
 
+START_TEST (parse_statment_params_types)
+{
+    result = cypher_parse("CYPHER int_val=1 float_val=2.3 true_val=true false_val=false null_val=NULL string_val='str' arr_val=[1,2,3] map_val={ int_val:1, float_val:2.3} RETURN 1", NULL, NULL, 0);
+
+    ck_assert(cypher_parse_result_fprint_ast(result, memstream, 0, NULL, 0) == 0);
+    fflush(memstream);
+    const char *expected = "\n"
+" @0    0..152  statement             options=[@1], body=@33\n"
+" @1    0..144  > CYPHER              params=[@2, @5, @8, @11, @14, @17, @20, @26]\n"
+" @2    7..17   > > cypher parameter  @3 = @4\n"
+" @3    7..14   > > > string          \"int_val\"\n"
+" @4   15..16   > > > integer         1\n"
+" @5   17..31   > > cypher parameter  @6 = @7\n"
+" @6   17..26   > > > string          \"float_val\"\n"
+" @7   27..30   > > > float           2.3\n"
+" @8   31..45   > > cypher parameter  @9 = @10\n"
+" @9   31..39   > > > string          \"true_val\"\n"
+"@10   40..44   > > > TRUE\n"
+"@11   45..61   > > cypher parameter  @12 = @13\n"
+"@12   45..54   > > > string          \"false_val\"\n"
+"@13   55..60   > > > FALSE\n"
+"@14   61..75   > > cypher parameter  @15 = @16\n"
+"@15   61..69   > > > string          \"null_val\"\n"
+"@16   70..74   > > > NULL\n"
+"@17   75..92   > > cypher parameter  @18 = @19\n"
+"@18   75..85   > > > string          \"string_val\"\n"
+"@19   86..91   > > > string          \"str\"\n"
+"@20   92..108  > > cypher parameter  @21 = @22\n"
+"@21   92..99   > > > string          \"arr_val\"\n"
+"@22  100..107  > > > collection      [@23, @24, @25]\n"
+"@23  101..102  > > > > integer       1\n"
+"@24  103..104  > > > > integer       2\n"
+"@25  105..106  > > > > integer       3\n"
+"@26  108..144  > > cypher parameter  @27 = @28\n"
+"@27  108..115  > > > string          \"map_val\"\n"
+"@28  116..143  > > > map             {@29:@30, @31:@32}\n"
+"@29  118..125  > > > > prop name     `int_val`\n"
+"@30  126..127  > > > > integer       1\n"
+"@31  129..138  > > > > prop name     `float_val`\n"
+"@32  139..142  > > > > float         2.3\n"
+"@33  144..152  > query               clauses=[@34]\n"
+"@34  144..152  > > RETURN            projections=[@35]\n"
+"@35  151..152  > > > projection      expression=@36, alias=@37\n"
+"@36  151..152  > > > > integer       1\n"
+"@37  151..152  > > > > identifier    `1`\n";
+    ck_assert_str_eq(memstream_buffer, expected);
+    ck_assert_int_eq(cypher_parse_result_ndirectives(result), 1);
+    const cypher_astnode_t *ast = cypher_parse_result_get_directive(result, 0);
+    ck_assert_int_eq(cypher_astnode_type(ast), CYPHER_AST_STATEMENT);
+
+    ck_assert_int_eq(cypher_ast_statement_noptions(ast), 1);
+    const cypher_astnode_t *option = cypher_ast_statement_get_option(ast, 0);
+    ck_assert(cypher_astnode_instanceof(option, CYPHER_AST_STATEMENT_OPTION));
+    ck_assert_int_eq(cypher_astnode_type(option), CYPHER_AST_CYPHER_OPTION);
+
+    ck_assert_int_eq(cypher_ast_cypher_option_nparams(option), 8);
+
+    const cypher_astnode_t *param =
+            cypher_ast_cypher_option_get_param(option, 0);
+    ck_assert_int_eq(cypher_astnode_type(param),
+            CYPHER_AST_CYPHER_OPTION_PARAM);
+
+    const cypher_astnode_t *name =
+            cypher_ast_cypher_option_param_get_name(param);
+    ck_assert_int_eq(cypher_astnode_type(name), CYPHER_AST_STRING);
+    const cypher_astnode_t *value = 
+            cypher_ast_cypher_option_param_get_value(param);
+    ck_assert_int_eq(cypher_astnode_type(value), CYPHER_AST_INTEGER);
+    ck_assert_str_eq(cypher_ast_string_get_value(name), "int_val");
+    ck_assert_str_eq(cypher_ast_integer_get_valuestr(value), "1");
+
+    param = cypher_ast_cypher_option_get_param(option, 1);
+    ck_assert_int_eq(cypher_astnode_type(param),CYPHER_AST_CYPHER_OPTION_PARAM);
+    name = cypher_ast_cypher_option_param_get_name(param);
+    ck_assert_int_eq(cypher_astnode_type(name), CYPHER_AST_STRING);
+    value = cypher_ast_cypher_option_param_get_value(param);
+    ck_assert_int_eq(cypher_astnode_type(value), CYPHER_AST_FLOAT);
+    ck_assert_str_eq(cypher_ast_string_get_value(name), "float_val");
+    ck_assert_str_eq(cypher_ast_float_get_valuestr(value), "2.3");
+
+    param = cypher_ast_cypher_option_get_param(option, 2);
+    ck_assert_int_eq(cypher_astnode_type(param),
+            CYPHER_AST_CYPHER_OPTION_PARAM);
+    name = cypher_ast_cypher_option_param_get_name(param);
+    ck_assert_int_eq(cypher_astnode_type(name), CYPHER_AST_STRING);
+    value = cypher_ast_cypher_option_param_get_value(param);
+    ck_assert_int_eq(cypher_astnode_type(value), CYPHER_AST_TRUE);
+    ck_assert_str_eq(cypher_ast_string_get_value(name), "true_val");
+
+    param = cypher_ast_cypher_option_get_param(option, 3);
+    ck_assert_int_eq(cypher_astnode_type(param),
+            CYPHER_AST_CYPHER_OPTION_PARAM);
+    name = cypher_ast_cypher_option_param_get_name(param);
+    ck_assert_int_eq(cypher_astnode_type(name), CYPHER_AST_STRING);
+    value = cypher_ast_cypher_option_param_get_value(param);
+    ck_assert_int_eq(cypher_astnode_type(value), CYPHER_AST_FALSE);
+    ck_assert_str_eq(cypher_ast_string_get_value(name), "false_val");
+
+    param = cypher_ast_cypher_option_get_param(option, 4);
+    ck_assert_int_eq(cypher_astnode_type(param),
+            CYPHER_AST_CYPHER_OPTION_PARAM);
+    name = cypher_ast_cypher_option_param_get_name(param);
+    ck_assert_int_eq(cypher_astnode_type(name), CYPHER_AST_STRING);
+    value = cypher_ast_cypher_option_param_get_value(param);
+    ck_assert_int_eq(cypher_astnode_type(value), CYPHER_AST_NULL);
+    ck_assert_str_eq(cypher_ast_string_get_value(name), "null_val");
+
+    param = cypher_ast_cypher_option_get_param(option, 5);
+    ck_assert_int_eq(cypher_astnode_type(param),
+            CYPHER_AST_CYPHER_OPTION_PARAM);
+    name = cypher_ast_cypher_option_param_get_name(param);
+    ck_assert_int_eq(cypher_astnode_type(name), CYPHER_AST_STRING);
+    value = cypher_ast_cypher_option_param_get_value(param);
+    ck_assert_int_eq(cypher_astnode_type(value), CYPHER_AST_STRING);
+    ck_assert_str_eq(cypher_ast_string_get_value(name), "string_val");
+    ck_assert_str_eq(cypher_ast_string_get_value(value), "str");
+
+    param = cypher_ast_cypher_option_get_param(option, 6);
+    ck_assert_int_eq(cypher_astnode_type(param),
+            CYPHER_AST_CYPHER_OPTION_PARAM);
+    name = cypher_ast_cypher_option_param_get_name(param);
+    ck_assert_int_eq(cypher_astnode_type(name), CYPHER_AST_STRING);
+    value = cypher_ast_cypher_option_param_get_value(param);
+    ck_assert_int_eq(cypher_astnode_type(value), CYPHER_AST_COLLECTION);
+    ck_assert_str_eq(cypher_ast_string_get_value(name), "arr_val");
+
+    param = cypher_ast_cypher_option_get_param(option, 7);
+    ck_assert_int_eq(cypher_astnode_type(param),
+            CYPHER_AST_CYPHER_OPTION_PARAM);
+    name = cypher_ast_cypher_option_param_get_name(param);
+    ck_assert_int_eq(cypher_astnode_type(name), CYPHER_AST_STRING);
+    value = cypher_ast_cypher_option_param_get_value(param);
+    ck_assert_int_eq(cypher_astnode_type(value), CYPHER_AST_MAP);
+    ck_assert_str_eq(cypher_ast_string_get_value(name), "map_val");
+}
+END_TEST
+
+
 START_TEST (parse_statement_with_cypher_option_containing_params)
 {
-    result = cypher_parse("CYPHER runtime=fast RETURN 1;",
+    result = cypher_parse("CYPHER runtime=\"fast\" RETURN 1;",
             NULL, NULL, 0);
 
     ck_assert(cypher_parse_result_fprint_ast(result, memstream, 0, NULL, 0) == 0);
     fflush(memstream);
     const char *expected = "\n"
-"@0   0..29  statement             options=[@1], body=@5\n"
-"@1   0..19  > CYPHER              params=[@2]\n"
-"@2   7..19  > > cypher parameter  @3 = @4\n"
+"@0   0..31  statement             options=[@1], body=@5\n"
+"@1   0..22  > CYPHER              params=[@2]\n"
+"@2   7..22  > > cypher parameter  @3 = @4\n"
 "@3   7..14  > > > string          \"runtime\"\n"
-"@4  15..19  > > > string          \"fast\"\n"
-"@5  20..29  > query               clauses=[@6]\n"
-"@6  20..28  > > RETURN            projections=[@7]\n"
-"@7  27..28  > > > projection      expression=@8, alias=@9\n"
-"@8  27..28  > > > > integer       1\n"
-"@9  27..28  > > > > identifier    `1`\n";
+"@4  15..21  > > > string          \"fast\"\n"
+"@5  22..31  > query               clauses=[@6]\n"
+"@6  22..30  > > RETURN            projections=[@7]\n"
+"@7  29..30  > > > projection      expression=@8, alias=@9\n"
+"@8  29..30  > > > > integer       1\n"
+"@9  29..30  > > > > identifier    `1`\n";
     ck_assert_str_eq(memstream_buffer, expected);
 
     ck_assert_int_eq(cypher_parse_result_ndirectives(result), 1);
@@ -200,26 +338,26 @@ END_TEST
 
 START_TEST (parse_statement_with_cypher_option_containing_version_and_params)
 {
-    result = cypher_parse("CYPHER 2.3 runtime=fast planner=slow RETURN 1;",
+    result = cypher_parse("CYPHER 2.3 runtime=\"fast\" planner=\"slow\" RETURN 1;",
             NULL, NULL, 0);
 
     ck_assert(cypher_parse_result_fprint_ast(result, memstream, 0, NULL, 0) == 0);
     fflush(memstream);
     const char *expected = "\n"
-" @0   0..46  statement             options=[@1], body=@9\n"
-" @1   0..36  > CYPHER              version=@2, params=[@3, @6]\n"
+" @0   0..50  statement             options=[@1], body=@9\n"
+" @1   0..41  > CYPHER              version=@2, params=[@3, @6]\n"
 " @2   7..10  > > string            \"2.3\"\n"
-" @3  11..23  > > cypher parameter  @4 = @5\n"
+" @3  11..26  > > cypher parameter  @4 = @5\n"
 " @4  11..18  > > > string          \"runtime\"\n"
-" @5  19..23  > > > string          \"fast\"\n"
-" @6  24..36  > > cypher parameter  @7 = @8\n"
-" @7  24..31  > > > string          \"planner\"\n"
-" @8  32..36  > > > string          \"slow\"\n"
-" @9  37..46  > query               clauses=[@10]\n"
-"@10  37..45  > > RETURN            projections=[@11]\n"
-"@11  44..45  > > > projection      expression=@12, alias=@13\n"
-"@12  44..45  > > > > integer       1\n"
-"@13  44..45  > > > > identifier    `1`\n";
+" @5  19..25  > > > string          \"fast\"\n"
+" @6  26..41  > > cypher parameter  @7 = @8\n"
+" @7  26..33  > > > string          \"planner\"\n"
+" @8  34..40  > > > string          \"slow\"\n"
+" @9  41..50  > query               clauses=[@10]\n"
+"@10  41..49  > > RETURN            projections=[@11]\n"
+"@11  48..49  > > > projection      expression=@12, alias=@13\n"
+"@12  48..49  > > > > integer       1\n"
+"@13  48..49  > > > > identifier    `1`\n";
     ck_assert_str_eq(memstream_buffer, expected);
 
     ck_assert_int_eq(cypher_parse_result_ndirectives(result), 1);


### PR DESCRIPTION
Hi @cleishm 
This PR adds the ability to know the types for given parameters. The use case for this feature is when given a parameterized query and its parameters, the `libcypher-parser` users can get the type of the parameters, and as a direct result, to evaluate the value of any given query parameter.