### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,8 @@ libcypher-parser (0.6.2-2) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
   * Drop unnecessary dependency on dh-autoreconf.
+  * Apply multi-arch hints.
+    + libcypher-parser-doc: Add Multi-Arch: foreign.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 19:21:25 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -58,6 +58,7 @@ Section: doc
 Architecture: all
 Depends: libjs-jquery, ${misc:Depends}
 Recommends: libcypher-parser-dev
+Multi-Arch: foreign
 Description: Documentation for libcypher-parser
  Cypher is a graph query language that allows for expressive and efficient
  querying of graph data.


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* libcypher-parser-doc: Add Multi-Arch: foreign. This fixes: libcypher-parser-doc could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/libcypher-parser/d491fb81-2136-4257-bb25-f397c2526f06.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)

No differences were encountered between the control files of package \*\*cypher-lint\*\*

No differences were encountered between the control files of package \*\*cypher-lint-dbgsym\*\*

No differences were encountered between the control files of package \*\*libcypher-parser-dev\*\*
### Control files of package libcypher-parser-doc: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}

No differences were encountered between the control files of package \*\*libcypher-parser8\*\*

No differences were encountered between the control files of package \*\*libcypher-parser8-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/d491fb81-2136-4257-bb25-f397c2526f06/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/d491fb81-2136-4257-bb25-f397c2526f06/diffoscope)).
